### PR TITLE
Update Stack resolver for new hakyl docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: futtetennista/hakyll:latest
+      - image: futtetennista/hakyll:4.12.5.1
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.14
+resolver: lts-13.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -39,7 +39,9 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- hakyll-4.12.5.1
+- lrucache-1.2.0.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Update the Stack resolver version to match the Stack version installed in the Hakyll Docker image, and switch to using a version number for the Docker image instead of the latest.